### PR TITLE
BDC schema upgrades (Jan 2024)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,14 @@
 # Love Language Schemas
 
-Love Language schemas attempt to encode concepts useful in building information systems for Human betterment. Each concept comes with a description describing the fields and possible values. System designers may find it useful that these schemas are defined using JSON Schema (Draft 7). 
+Love Language schemas attempt to encode concepts useful in building information systems for Human betterment. Each concept comes with a description describing the fields and possible values. System designers may find it useful that these schemas are defined using JSON Schema (Draft 2020).
 
 
 ## Schemas
 
 Included in this work are schemas for the following concepts:
 
-- [Use of Force](./examples/use-of-force/README.md)
+- [Broadband Data Collection - Bulk Fixed Crowdsourced Data]("https://us-fcc.app.box.com/v/bdc-bulk-fixed-challenge-spec")
+- [Department of Justice - Use of Force Continuum](./examples/use-of-force/README.md)
 - Environmental Sensors
 - Legislation
 - Open Data

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Love Language schemas attempt to encode concepts useful in building information 
 
 Included in this work are schemas for the following concepts:
 
-- [Broadband Data Collection - Bulk Fixed Crowdsourced Data]("https://us-fcc.app.box.com/v/bdc-bulk-fixed-challenge-spec")
+- [Broadband Data Collection - Bulk Fixed Crowdsourced Data](https://us-fcc.app.box.com/v/bdc-bulk-fixed-challenge-spec)
 - [Department of Justice - Use of Force Continuum](./examples/use-of-force/README.md)
 - Environmental Sensors
 - Legislation

--- a/schemas/knowledge-of-infrastructure.schema.json
+++ b/schemas/knowledge-of-infrastructure.schema.json
@@ -80,7 +80,7 @@
         "if": {
             "properties": {
                 "category_code": {
-                    "enum": [5, 6]
+                    "enum": [5, 6, 7]
                 }
             }
         },

--- a/schemas/knowledge-of-infrastructure.schema.json
+++ b/schemas/knowledge-of-infrastructure.schema.json
@@ -16,7 +16,7 @@
           "description": "Brand name of the service subject to the crowdsource submission, as shown on the Broadband Map."
         },
         "technology": {
-          "type": "integer",
+          "enum": [0, 10 , 40, 50, 60, 61, 70, 71],
           "description": "Code for the technology of the service subject to the crowdsource submission, as shown on the Broadband Map."
         },
         "location_id": {

--- a/schemas/knowledge-of-infrastructure.schema.json
+++ b/schemas/knowledge-of-infrastructure.schema.json
@@ -61,28 +61,17 @@
       {
         "if": {
             "properties": {
-                "technology": {
+                "category_code": {
                     "type": "integer",
-                    "minimum": 60,
-                    "maximum": 71
+                    "minimum": 8,
+                    "maximum": 9
                 }
             }
         },
         "then": {
             "properties": {
-                "category_code": {
-                    "type": "integer",
-                    "minimum": 1,
-                    "maximum": 9
-                }
-            }
-        },
-        "else": {
-            "properties": {
-                "category_code": {
-                    "type": "integer",
-                    "minimum": 1,
-                    "maximum": 7
+                "technology": {
+                    "enum": [60, 61, 70, 71]
                 }
             }
         }

--- a/schemas/knowledge-of-infrastructure.schema.json
+++ b/schemas/knowledge-of-infrastructure.schema.json
@@ -19,6 +19,10 @@
           "enum": [0, 10 , 40, 50, 60, 61, 70, 71],
           "description": "Code for the technology of the service subject to the crowdsource submission, as shown on the Broadband Map."
         },
+        "bizrescode": {
+          "enum": ["B", "R", "X", null],
+          "description": "Enumerated character identifying whether the service in the area is business-only, residential-only, or offered to both business and residential customers"
+        },
         "location_id": {
           "type": "string",
           "description": "Unique identifier for the location, from the Broadband Serviceable Location Fabric, about which crowdsource information on fixed broadband availability is being submitted."

--- a/schemas/knowledge-of-infrastructure.schema.json
+++ b/schemas/knowledge-of-infrastructure.schema.json
@@ -36,7 +36,7 @@
           "type": "integer",
           "description": "Code identifying the category of fixed service provider crowdsource submission.",
           "minimum": 1,
-          "maximum": 7
+          "maximum": 10
         },
         "request_date": {
           "type": "string",

--- a/schemas/knowledge-of-infrastructure.schema.json
+++ b/schemas/knowledge-of-infrastructure.schema.json
@@ -80,9 +80,7 @@
         "if": {
             "properties": {
                 "category_code": {
-                    "type": "integer",
-                    "minimum": 5,
-                    "maximum": 7
+                    "enum": [5, 6]
                 }
             }
         },

--- a/schemas/other-methologies-two-and-three.schema.json
+++ b/schemas/other-methologies-two-and-three.schema.json
@@ -73,28 +73,17 @@
       {
         "if": {
             "properties": {
-                "technology": {
+                "category_code": {
                     "type": "integer",
-                    "minimum": 60,
-                    "maximum": 71
+                    "minimum": 8,
+                    "maximum": 9
                 }
             }
         },
         "then": {
             "properties": {
-                "category_code": {
-                    "type": "integer",
-                    "minimum": 1,
-                    "maximum": 9
-                }
-            }
-        },
-        "else": {
-            "properties": {
-                "category_code": {
-                    "type": "integer",
-                    "minimum": 1,
-                    "maximum": 7
+                "technology": {
+                    "enum": [60, 61, 70, 71]
                 }
             }
         }
@@ -103,9 +92,7 @@
         "if": {
             "properties": {
                 "category_code": {
-                    "type": "integer",
-                    "minimum": 5,
-                    "maximum": 7
+                    "enum": [5, 6, 7]
                 }
             }
         },

--- a/schemas/other-methologies-two-and-three.schema.json
+++ b/schemas/other-methologies-two-and-three.schema.json
@@ -31,6 +31,10 @@
           "type": "integer",
           "description": "Code for the technology of the service subject to the crowdsource submission, as shown on the Broadband Map."
         },
+        "bizrescode": {
+          "enum": ["B", "R", "X", null],
+          "description": "Enumerated character identifying whether the service in the area is business-only, residential-only, or offered to both business and residential customers"
+        },
         "location_id": {
           "type": "string",
           "description": "Unique identifier for the location, from the Broadband Serviceable Location Fabric, about which crowdsource information on fixed broadband availability is being submitted."


### PR DESCRIPTION
## Summary of updates

- The `technology` code field is now enumerable from 1 to 10.
- new `bizrescode` field see page 16: https://us-fcc.app.box.com/v/bdc-bulk-fixed-challenge-spec
- updated subschemas for `request_date`, `category_code` and `request_method_code` fields

closes #9 